### PR TITLE
feat: experiment with `philosofonusus/ecolog.nvim`

### DIFF
--- a/lua/plugins/completion.lua
+++ b/lua/plugins/completion.lua
@@ -32,6 +32,7 @@ return {
           { name = 'luasnip' },
           { name = 'path' },
           { name = 'lazydev', group_index = 0 },
+          { name = 'ecolog' },
         }, {
           { name = 'buffer', keyword_length = 5 },
         }),

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -117,6 +117,49 @@ return {
     lazy = true,
   },
 
+  {
+    'philosofonusus/ecolog.nvim',
+    lazy = false,
+    ---@module 'ecolog'
+    ---@type EcologConfig
+    opts = {
+      types = {
+        boolean = false,
+        database_url = true,
+        ipv4 = true,
+      },
+      integrations = {
+        lsp = true,
+        fzf = true,
+        statusline = true,
+      },
+      shelter = {
+        configuration = {
+          patterns = {
+            ['*_DSN'] = 'full',
+            ['*_KEY'] = 'full',
+            ['*_PASS'] = 'full',
+            ['*_PASSWORD'] = 'full',
+            ['*_TOKEN'] = 'full',
+            ['*_USER'] = 'full',
+            ['*_USERNAME'] = 'full',
+          },
+          sources = {
+            ['.env.*'] = 'full',
+            ['.env'] = 'partial',
+            ['.env.example'] = 'none',
+          },
+        },
+        modules = {
+          cmp = true,
+          files = true,
+          telescope_previewer = true,
+          fzf_previewer = true,
+        }
+      }
+    },
+  },
+
   -- {
   --   'akinsho/bufferline.nvim',
   --   opts = {


### PR DESCRIPTION
A plugin that claims to provide privacy over our `dotenv` files by hiding/masking the values of all environment variables and apparently has quite a lot of feature out of the box.

Previously I've tried `laytan/cloak.nvim` after watching video from TJ DeVries. But after seeing laytan/cloak.nvim#17 and find out that `ecolog.nvim` has quite interesting features I decided to give it a try.

Either of them give good enough first impression with few differences.

### `cloak.nvim`

<img width="912" alt="cloak.nvim preview" src="https://github.com/user-attachments/assets/d7e1b19c-6ea7-4894-a5a9-98ba918f6520" />

1. Comments are masked 👍🏻 
2. Mask all value including the quote `'` & `"` 🤌🏻
3. Don't mess up my current `tree-sitter-dotenv` 👍🏻 
4. Provide bare minimun documentation 🤌🏻

### `ecolog.nvim`

<img width="912" alt="ecolog.nvim preview" src="https://github.com/user-attachments/assets/06eea130-f03f-4f49-9c2e-3bc8c0c14ea0" />

1. Comments are skipped, and seems [nothing I can do](https://github.com/philosofonusus/ecolog.nvim/blob/3d8056ea46773222b375978d384495c8b9f3df6e/lua/ecolog/shelter/buffer.lua#L127-L129) about it 👎🏻 
2. Mask the value inside the quote 👍🏻 
3. Mess up my `tree-sitter-dotenv` and replace the filetype with `sh` instead 👎🏻 
4. Despite providing great documentation but when I tried configure it to my liking it seems has no effects at all, or am I just stupid ✌🏻