### PR TITLE
feat: experiment with `laytan/cloak.nvim`

### DIFF
--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -119,24 +119,26 @@ return {
 
   {
     'laytan/cloak.nvim',
-    lazy = false,
     ---@module 'cloak'
     opts = {
       patterns = {
         {
-          file_pattern = '.env*',
           cloak_pattern = {
-            '(%u+_ID=).+',
-            '(%u+_DSN=).+',
-            '(%u+_KEY=).+',
-            '(%u+_PASS=).+',
-            '(%u+_PASSWORD=).+',
-            '(%u+_USER=).+',
-            '(%u+_USERNAME=).+',
-            '(%u+_TOKEN=).+',
+            '(%u+_ID)=.+',
+            '(%u+_DSN)=.+',
+            '(%u+_KEY)=.+',
+            '(%u+_PASS)=.+',
+            '(%u+_PASSWORD)=.+',
+            '(%u+_SECRET)=.+',
+            '(%u+_TOKEN)=.+',
+            '(%u+_USER)=.+',
+            '(%u+_USERNAME)=.+',
+            '(%u+)=(%a+://).+',
+            '(%u+)=\'(%a+://).+\'$',
+            '(%u+)="(%a+://).+"$',
           },
-          replace = '%1'
-        }
+          replace = '%1='
+        },
       }
     },
   },

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -120,7 +120,25 @@ return {
   {
     'laytan/cloak.nvim',
     lazy = false,
-    opts = {},
+    ---@module 'cloak'
+    opts = {
+      patterns = {
+        {
+          file_pattern = '.env*',
+          cloak_pattern = {
+            '(%u+_ID=).+',
+            '(%u+_DSN=).+',
+            '(%u+_KEY=).+',
+            '(%u+_PASS=).+',
+            '(%u+_PASSWORD=).+',
+            '(%u+_USER=).+',
+            '(%u+_USERNAME=).+',
+            '(%u+_TOKEN=).+',
+          },
+          replace = '%1'
+        }
+      }
+    },
   },
 
   -- {

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -121,18 +121,18 @@ return {
     'laytan/cloak.nvim',
     ---@module 'cloak'
     opts = {
+      cloak_telescope = true,
       patterns = {
         {
           cloak_pattern = {
             '(%u+_ID)=.+',
             '(%u+_DSN)=.+',
             '(%u+_KEY)=.+',
-            '(%u+_PASS)=.+',
-            '(%u+_PASSWORD)=.+',
-            '(%u+_SECRET)=.+',
+            '(%u+_PASS%u+)=.+',
+            '(%u+_PRIVATE%u+)=.+',
+            '(%u+_SECRET%u+)=.+',
             '(%u+_TOKEN)=.+',
-            '(%u+_USER)=.+',
-            '(%u+_USERNAME)=.+',
+            '(%u+_USER%u+)=.+',
             '(%u+)=(%a+://).+',
             '(%u+)=\'(%a+://).+\'$',
             '(%u+)="(%a+://).+"$',

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -117,6 +117,12 @@ return {
     lazy = true,
   },
 
+  {
+    'laytan/cloak.nvim',
+    lazy = false,
+    opts = {},
+  },
+
   -- {
   --   'akinsho/bufferline.nvim',
   --   opts = {


### PR DESCRIPTION
Based on #1 I decided to messing around with the `cloak.nvim` config a lil' bit more.

<img width="912" alt="My dotenv preview with cloak.nvim" src="https://github.com/user-attachments/assets/f34730ff-0822-49d6-9094-4bba71176be6" />

and figured out that the configurations is quite simple despite the documentation is somewhat mininum. I've also learnt how pattern matching works [in lua](https://www.lua.org/pil/20.1.html) along the way.

At this time I configure it to only masking keys with `*_ID`, `*_DSN`, `*_KEY`,
`*_PASS`, `*_PASSWORD`, `*_SECRET`, `*_TOKEN`, `*_USER`, `*_USERNAME` and any keys that has value in `DSN` or database URL format, e.g. `<driver>://<user>:<pass>@<host>`.

That's might be enough for what I needed now since I don't want to mask all the value in my `.env*` file.