### PR TITLE
feat(terminal): init terminal configuration using `akinsho/toggleterm.nvim`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@
 - Panes / Splits
   - `ALT`+`Up`/`Down` arrow : Increase or decrease window height
   - `ALT`+`Left`/`Right` arrow : Decrease or increase window width
-  - `<leader>`+`h`/`j`/`k`/`l` : Jump to `left`, `below`, `above` or `right` window
+  - `CTRL`+`h`/`j`/`k`/`l` : Jump to `left`, `below`, `above` or `right` window
+  - `CTRL`+<code>`</code> : Toggle integrated terminal
 - File Navigations
   - `[b` and `]b` : Jump to previous and next buffer windows
   - `n` and `N` : Jump to previous and next search results and keep the cursor in the center

--- a/lua/keymaps.lua
+++ b/lua/keymaps.lua
@@ -27,10 +27,10 @@ vim.keymap.set('v', '<A-j>', ":move'>+1<CR>gv=gv", { noremap = true, desc = 'Mov
 vim.keymap.set('v', '<A-k>', ":move'<-2<CR>gv=gv", { noremap = true, desc = 'Move lines up' })
 
 -- Split navigation - use <leader>H/J/K/L instead of CTRL+H/J/K/L to navigate window
-vim.keymap.set('n', '<leader>h', '<C-w>h', { noremap = true, desc = 'Go to left window' })
-vim.keymap.set('n', '<leader>j', '<C-w>j', { noremap = true, desc = 'Go to window below' })
-vim.keymap.set('n', '<leader>k', '<C-w>k', { noremap = true, desc = 'Go to window above' })
-vim.keymap.set('n', '<leader>l', '<C-w>l', { noremap = true, desc = 'Go to right window' })
+vim.keymap.set('n', '<C-h>', '<C-w>h', { noremap = true, desc = 'Go to left window' })
+vim.keymap.set('n', '<C-j>', '<C-w>j', { noremap = true, desc = 'Go to window below' })
+vim.keymap.set('n', '<C-k>', '<C-w>k', { noremap = true, desc = 'Go to window above' })
+vim.keymap.set('n', '<C-l>', '<C-w>l', { noremap = true, desc = 'Go to right window' })
 
 -- Resize window - Use CTRL + arrow keys
 vim.keymap.set('n', '<A-Up>', '<Cmd>resize+2<CR>', { desc = 'Increase window height' })
@@ -39,8 +39,8 @@ vim.keymap.set('n', '<A-Left>', '<Cmd>vertical resize-2<CR>', { desc = 'Decrease
 vim.keymap.set('n', '<A-Right>', '<Cmd>vertical resize+2<CR>', { desc = 'Increase window width' })
 
 -- Speed up viewport scrolling
-vim.keymap.set('n', '<C-j>', '4<C-e>', { desc = 'Scroll 4 lines down' })
-vim.keymap.set('n', '<C-k>', '4<C-y>', { desc = 'Scroll 4 lines up' })
+-- vim.keymap.set('n', '<C-J>', '4<C-e>', { desc = 'Scroll 4 lines down' })
+-- vim.keymap.set('n', '<C-K>', '4<C-y>', { desc = 'Scroll 4 lines up' })
 
 -- Buffers navigation
 vim.keymap.set('n', '[b', vim.cmd.bprevious, { noremap = true, desc = 'Previous Buffer' })

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -45,28 +45,6 @@ return {
   },
 
   {
-    'kdheepak/lazygit.nvim',
-    lazy = true,
-    cmd = {
-        'LazyGit',
-        -- 'LazyGitConfig',
-        -- 'LazyGitCurrentFile',
-        -- 'LazyGitFilter',
-        -- 'LazyGitFilterCurrentFile',
-    },
-    dependencies = {
-      { 'nvim-lua/plenary.nvim' },
-      { 'nvim-telescope/telescope.nvim' }
-    },
-    keys = {
-      { '<leader>lg', '<cmd>LazyGit<cr>', desc = 'LazyGit' }
-    },
-    config = function ()
-      require('telescope').load_extension('lazygit')
-    end
-  },
-
-  {
     'folke/which-key.nvim',
     dependencies = {
       { 'nvim-tree/nvim-web-devicons' },

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -169,6 +169,19 @@ return {
     dependencies = {
       { 'nvim-tree/nvim-web-devicons' },
     },
+    opts = function(_, opts)
+      vim.o.laststatus = vim.g.lualine_laststatus
+
+      opts.options = {
+        theme = 'auto',
+        globalstatus = true,
+        disabled_filetypes = { 'dashboard', 'alpha', 'starter' },
+        componnet_separators = '',
+        section_separators = '',
+      }
+
+      opts.extensions = { 'neo-tree', 'lazy', 'toggleterm' }
+    end,
     init = function()
       vim.g.lualine_laststatus = vim.o.laststatus
 
@@ -177,20 +190,6 @@ return {
       else
         vim.o.laststatus = 0
       end
-    end,
-    opts = function()
-      vim.o.laststatus = vim.g.lualine_laststatus
-
-      return {
-        options = {
-          theme = 'auto',
-          globalstatus = true,
-          disabled_filetypes = { 'dashboard', 'alpha', 'starter' },
-          componnet_separators = '',
-          section_separators = '',
-        },
-        extensions = { 'neo-tree', 'lazy' },
-      }
     end,
   },
 }

--- a/lua/plugins/terminal.lua
+++ b/lua/plugins/terminal.lua
@@ -22,14 +22,14 @@ return {
           -- Disable sign-column in terminal window
           vim.opt_local.signcolumn = 'no'
 
-          vim.keymap.set('t', '<esc>', [[<C-\><C-n>]], opts)
+          vim.keymap.set('t', '<esc>', '<C-\\><C-n>', opts)
 
-          -- vim.keymap.set('t', 'jk', [[<C-\><C-n>]], opts)
-          -- vim.keymap.set('t', '<C-w>', [[<C-\><C-n><C-w>]], opts)
-          vim.keymap.set('t', '<leader>h', [[<Cmd>wincmd h<CR>]], { desc = 'Go to left window'  })
-          vim.keymap.set('t', '<leader>j', [[<Cmd>wincmd j<CR>]], { desc = 'Go to window below' })
-          vim.keymap.set('t', '<leader>k', [[<Cmd>wincmd k<CR>]], { desc = 'Go to window above' })
-          vim.keymap.set('t', '<leader>l', [[<Cmd>wincmd l<CR>]], { desc = 'Go to right window' })
+          -- vim.keymap.set('t', 'jk', '<C-\><C-n>', opts)
+          vim.keymap.set('t', '<C-w>', '<C-\\><C-n><C-w>', opts)
+          vim.keymap.set('t', '<C-h>', '<Cmd>wincmd h<CR>', { desc = 'Go to left window'  })
+          vim.keymap.set('t', '<C-j>', '<Cmd>wincmd j<CR>', { desc = 'Go to window below' })
+          vim.keymap.set('t', '<C-k>', '<Cmd>wincmd k<CR>', { desc = 'Go to window above' })
+          vim.keymap.set('t', '<C-l>', '<Cmd>wincmd l<CR>', { desc = 'Go to right window' })
         end
       })
 

--- a/lua/plugins/terminal.lua
+++ b/lua/plugins/terminal.lua
@@ -13,10 +13,27 @@ return {
       }
     },
     init = function ()
-      local opts = { buffer = 0 }
-      local Terminal = require('toggleterm.terminal').Terminal
+      -- Configure terminal's local options and keymaps
+      vim.api.nvim_create_autocmd({ 'TermOpen' }, {
+        pattern = 'term://*',
+        callback = function ()
+          local opts = { buffer = 0 }
 
-      vim.keymap.set({'t'}, '<Esc>', [[<C-\><C-n>]], opts)
+          -- Disable sign-column in terminal window
+          vim.opt_local.signcolumn = 'no'
+
+          vim.keymap.set('t', '<esc>', [[<C-\><C-n>]], opts)
+
+          -- vim.keymap.set('t', 'jk', [[<C-\><C-n>]], opts)
+          -- vim.keymap.set('t', '<C-w>', [[<C-\><C-n><C-w>]], opts)
+          vim.keymap.set('t', '<leader>h', [[<Cmd>wincmd h<CR>]], { desc = 'Go to left window'  })
+          vim.keymap.set('t', '<leader>j', [[<Cmd>wincmd j<CR>]], { desc = 'Go to window below' })
+          vim.keymap.set('t', '<leader>k', [[<Cmd>wincmd k<CR>]], { desc = 'Go to window above' })
+          vim.keymap.set('t', '<leader>l', [[<Cmd>wincmd l<CR>]], { desc = 'Go to right window' })
+        end
+      })
+
+      local Terminal = require('toggleterm.terminal').Terminal
 
       local lazygit = Terminal:new({
         cmd = 'lazygit',

--- a/lua/plugins/terminal.lua
+++ b/lua/plugins/terminal.lua
@@ -1,0 +1,32 @@
+return {
+  {
+    'akinsho/toggleterm.nvim',
+    version = '*',
+    event = { 'VimEnter' },
+    ---@module 'toggleterm'
+    ---@type ToggleTermConfig
+    opts = {
+      hide_numbers = true,
+      open_mapping = [[<c-`>]],
+      float_opts = {
+        border = 'curved',
+      }
+    },
+    init = function ()
+      local opts = { buffer = 0 }
+      local Terminal = require('toggleterm.terminal').Terminal
+
+      vim.keymap.set({'t'}, '<Esc>', [[<C-\><C-n>]], opts)
+
+      local lazygit = Terminal:new({
+        cmd = 'lazygit',
+        dir = 'git_dir',
+        direction = 'float',
+      })
+
+      vim.keymap.set({'n'}, '<leader>gl', function ()
+        lazygit:toggle()
+      end, { desc = 'Toggle LazyGit' })
+    end,
+  },
+}


### PR DESCRIPTION
Considering the way `kdhepak/lazygit` works that simply _launching_ `lazygit` using vim built-in terminal and make it _float_ is got me thinking ...

> Should I just configure the built-in terminal so I can launch any command line programs I want (instead just `lazygit`) in floating window and make better interactions that I've already used to? 

As per `kdhepak/lazygit` states in their readme, they're recommending `akinsho/toggleterm.nvim` as an alternative so I decided to give it a shot.

At glance I noticed that `toggleterm` offers much more options than just `lazygit`
launcher, though I won't be using all of them but at least I have some rooms
to improve and learn later on.

I'm using <kbd>CTRL+`</kbd> to toggle the terminal in the bottom of current buffer as I've already used to in VSCode.

On their readme they're suggesting to [remap the window navigations](https://github.com/akinsho/toggleterm.nvim#terminal-window-mappings) via <kbd>CTRL+H/J/K/L</kbd> but since my split navigations is already mapped to

https://github.com/feryardiant/config-nvim/blob/409643978aa5a51381dd4677bcffc8e0bdc22af4/lua/keymaps.lua#L29-L33

Isn't that easier to remember if we have the same mapping, right?

And back to `lazygit`, let's use `<leader>gl` to toggle it as floating window and here's the result.

https://github.com/user-attachments/assets/a67ad97f-9fe9-4ce2-9228-9c9536a40a7f

And since my `<leader>` key was `space`, I noticed that everytime I types `space`s wheter creating commit or adding files to `staged` in `lazygit`, I feels the delay 😅 