### PR TITLE
fix(terminal): fix key mapping while in terminal

### DIFF
--- a/lua/plugins/terminal.lua
+++ b/lua/plugins/terminal.lua
@@ -7,7 +7,7 @@ return {
     ---@type ToggleTermConfig
     opts = {
       hide_numbers = true,
-      open_mapping = [[<c-`>]],
+      open_mapping = '<c-`>',
       float_opts = {
         border = 'curved',
       }
@@ -16,20 +16,23 @@ return {
       -- Configure terminal's local options and keymaps
       vim.api.nvim_create_autocmd({ 'TermOpen' }, {
         pattern = 'term://*',
-        callback = function ()
+        callback = function (args)
           local opts = { buffer = 0 }
+          local file_match = args.match or args.file
 
           -- Disable sign-column in terminal window
           vim.opt_local.signcolumn = 'no'
 
-          vim.keymap.set('t', '<esc>', '<C-\\><C-n>', opts)
+          if not string.find(file_match, 'lazygit') then
+            vim.keymap.set('t', '<Esc>', '<C-\\><C-n>', opts)
 
-          -- vim.keymap.set('t', 'jk', '<C-\><C-n>', opts)
-          vim.keymap.set('t', '<C-w>', '<C-\\><C-n><C-w>', opts)
-          vim.keymap.set('t', '<C-h>', '<Cmd>wincmd h<CR>', { desc = 'Go to left window'  })
-          vim.keymap.set('t', '<C-j>', '<Cmd>wincmd j<CR>', { desc = 'Go to window below' })
-          vim.keymap.set('t', '<C-k>', '<Cmd>wincmd k<CR>', { desc = 'Go to window above' })
-          vim.keymap.set('t', '<C-l>', '<Cmd>wincmd l<CR>', { desc = 'Go to right window' })
+            -- vim.keymap.set('t', 'jk', '<C-\><C-n>', opts)
+            -- vim.keymap.set('t', '<C-w>', '<C-\\><C-n><C-w>', opts)
+            vim.keymap.set('t', '<C-h>', '<Cmd>wincmd h<CR>', { desc = 'Go to left window'  })
+            vim.keymap.set('t', '<C-j>', '<Cmd>wincmd j<CR>', { desc = 'Go to window below' })
+            vim.keymap.set('t', '<C-k>', '<Cmd>wincmd k<CR>', { desc = 'Go to window above' })
+            vim.keymap.set('t', '<C-l>', '<Cmd>wincmd l<CR>', { desc = 'Go to right window' })
+          end
         end
       })
 
@@ -39,11 +42,12 @@ return {
         cmd = 'lazygit',
         dir = 'git_dir',
         direction = 'float',
+        hidden = true,
       })
 
       vim.keymap.set({'n'}, '<leader>gl', function ()
         lazygit:toggle()
-      end, { desc = 'Toggle LazyGit' })
+      end, { desc = 'Toggle LazyGit', noremap = true, silent = true })
     end,
   },
 }


### PR DESCRIPTION
Since the #3 I realized that the `Esc` key is bound to the terminal mode and any program running inside it won't be able to utilize it as it should be.

For instance when you use `lazygit` via `<leader>gl` then inside it you want to [cancel the commit or stash message](https://github.com/akinsho/toggleterm.nvim/issues/367), or may be you want to close the help menu, you won't be able to do that because the `Esc` key is bound to the terminal instead of the program itself.

The only possible way I can think off is to determine the terminal window I currently open and decide whether I should add the `keymap` or not. AFAIK, there's an argument that will be passed to the `autocmd` callback function and it's a `table` but I don't know what `fields` in it and which `field` I could rely on.

Then I realize that the fields is inconsistent, sometimes it has `match` field but another time it has `file` field. Although either field has exactly same value but their existance is quite cumbersome.

![Screenshot 2025-02-04 at 08 55 02](https://github.com/user-attachments/assets/795a1786-8110-4262-9888-69cf2df4c787)

![Screenshot 2025-02-04 at 08 54 22](https://github.com/user-attachments/assets/79f2b17b-4592-4ecc-b6bf-ce2882c6a552)

so let's check them

https://github.com/feryardiant/config-nvim/blob/94d174c0eb333ba05c444490947acf5b01964b6a/lua/plugins/terminal.lua#L21

and assign the keymap when it's not an `lazygit` terminal

https://github.com/feryardiant/config-nvim/blob/94d174c0eb333ba05c444490947acf5b01964b6a/lua/plugins/terminal.lua#L26-L35

Noticed I disable <kbd>CTRL+w</kbd> in [line 30](https://github.com/feryardiant/config-nvim/blob/94d174c0eb333ba05c444490947acf5b01964b6a/lua/plugins/terminal.lua#L30) due to I'm unable to use it as _delete word_ inside terminal 😅 