### PR TITLE
feat(debug): add ability to start built-in server and debugging at once

### DIFF
--- a/lua/custom/php.lua
+++ b/lua/custom/php.lua
@@ -1,0 +1,27 @@
+---@class PHP
+local PHP = {}
+local uv = vim.uv or vim.loop
+
+function PHP.is_laravel() return PHP.file_exists('/artisan') end
+
+---Check wheter file exists
+---@param file_path string
+---@return boolean
+function PHP.file_exists(file_path) return uv.fs_stat(vim.fn.getcwd() .. file_path) ~= nil end
+
+---Retrieve route file
+---@return string?
+function PHP.route_file()
+  local try_files = {
+    'server.php',
+    'vendor/laravel/framework/src/Illuminate/Foundation/resources/server.php',
+  }
+
+  for _, file in ipairs(try_files) do
+    if PHP.file_exists('/' .. file) then return file end
+  end
+
+  return nil
+end
+
+return PHP

--- a/lua/plugins/debug.lua
+++ b/lua/plugins/debug.lua
@@ -5,20 +5,43 @@ return {
       { 'mfussenegger/nvim-dap' },
       { 'nvim-neotest/nvim-nio' },
       { 'stevearc/dressing.nvim' },
-      { 'jay-babu/mason-nvim-dap.nvim' },
     },
     keys = {
       { '<F7>', function() require('dapui').toggle() end, desc = 'Debug: Toggle UI' },
     },
     ---@module 'dapui'
     ---@type dapui.Config
-    opts = {},
+    opts = {
+      controls = { element = 'watches' },
+      floating = { border = 'rounded' },
+      layouts = {
+        {
+          size = 32,
+          position = 'left',
+          elements = {
+            { size = 0.3, id = 'scopes' },
+            { size = 0.3, id = 'stacks' },
+            { size = 0.2, id = 'breakpoints' },
+            { size = 0.2, id = 'watches' },
+          },
+        },
+        {
+          size = 10,
+          position = 'bottom',
+          elements = {
+            { size = 0.6, id = 'repl' },
+            { size = 0.4, id = 'console' },
+          },
+        },
+      },
+    },
   },
 
   {
     'mfussenegger/nvim-dap',
     dependencies = {
       { 'theHamsta/nvim-dap-virtual-text' },
+      { 'jay-babu/mason-nvim-dap.nvim' },
     },
     keys = {
       { '<F5>', function() require('dap').continue() end, desc = 'Debug: Start/Continue' },
@@ -97,17 +120,17 @@ return {
             type = 'php',
             request = 'launch',
             name = 'DAP: Launch built-in server and Debug',
-            cwd = vim.fn.getcwd()..'/public',
+            cwd = vim.fn.getcwd() .. '/public',
             port = xdebug_port,
             runtimeArgs = {
               '-dxdebug.client_host=127.0.0.1',
-              '-dxdebug.client_port='..xdebug_port,
+              '-dxdebug.client_port=' .. xdebug_port,
               '-dxdebug.mode=debug',
               '-dxdebug.start_with_request=yes',
               '-S',
               'localhost:8000',
               '-t',
-              '.'
+              '.',
             },
           }
 
@@ -118,7 +141,7 @@ return {
 
           if route_file ~= nil then
             -- Assign route file when available
-            table.insert(dev_server.runtimeArgs, '../'..route_file)
+            table.insert(dev_server.runtimeArgs, '../' .. route_file)
           end
 
           table.insert(dap.configurations.php, dev_server)
@@ -208,7 +231,7 @@ return {
             url = enter_launch_url,
             webRoot = '${workspaceFolder}',
             sourceMaps = true,
-            firefoxExecutable = vim.fn.exepath('firefox')
+            firefoxExecutable = vim.fn.exepath('firefox'),
           })
         end
       end
@@ -216,20 +239,44 @@ return {
   },
 
   {
+    'jay-babu/mason-nvim-dap.nvim',
+    dependencies = {
+      { 'williamboman/mason.nvim' },
+    },
+    ---@module 'mason-nvim-dap'
+    ---@type MasonNvimDapSettings
+    opts = {
+      ensure_installed = {
+        'firefox-debug-adapter',
+        'js-debug-adapter',
+        'node-debug2-adapter',
+        'php-debug-adapter',
+      },
+    },
+  },
+
+  {
     'theHamsta/nvim-dap-virtual-text',
-    lazy = true,
     ---@module 'nvim-dap-virtual-text'
     ---@type nvim_dap_virtual_text_options
     opts = {
       display_callback = function(var)
-        local name = string.lower(var.name)
-        local value = string.lower(var.value)
+        local name = var.name:lower()
+        local value = var.value:lower()
 
-        if name:match('secret') or name:match('key') or name:match('api') then return '*****' end
+        if name:match('secret') or name:match('key') or name:match('api') then
+          -- Hide sensitive values
+          return ' *****'
+        end
 
-        if #value > 10 then return ' ' .. string.sub(var.value, 1, 10) .. '...' end
+        local output = var.value:gsub('%s+', ' ')
 
-        return var.value
+        if #value > 10 then
+          -- Shorten long value
+          return output:sub(1, 10) .. '...'
+        end
+
+        return output
       end,
     },
   },

--- a/lua/plugins/debug.lua
+++ b/lua/plugins/debug.lua
@@ -1,5 +1,3 @@
-local uv = vim.uv or vim.loop
-
 return {
   {
     'rcarriga/nvim-dap-ui',
@@ -86,7 +84,7 @@ return {
             {
               type = 'php',
               request = 'launch',
-              name = 'PHP: Listen for XDebug',
+              name = 'DAP: Listen for XDebug',
               port = xdebug_port,
               cwd = vim.fn.getcwd(),
             },
@@ -94,23 +92,18 @@ return {
         end
 
         if php.file_exists('/public/index.php') then
+          local route_file = php.route_file()
           local dev_server = {
             type = 'php',
             request = 'launch',
-            name = 'PHP: Launch Built-in web server',
-            cwd = vim.fn.getcwd() .. '/public',
+            name = 'DAP: Launch built-in server and Debug',
+            cwd = vim.fn.getcwd()..'/public',
             port = xdebug_port,
-            env = { XDEBUG_SESSION = '1' },
-            serverReadyAction = {
-              pattern = 'Development Server \\(http://localhost:([0-9]+)\\) started',
-              uriFormat = 'http://localhost:%s',
-              action = 'openExternally',
-            },
             runtimeArgs = {
               '-dxdebug.client_host=127.0.0.1',
               '-dxdebug.client_port='..xdebug_port,
               '-dxdebug.mode=debug',
-              '-dxdebug.start_with_request=1',
+              '-dxdebug.start_with_request=yes',
               '-S',
               'localhost:8000',
               '-t',
@@ -118,15 +111,14 @@ return {
             },
           }
 
-          if php.file_exists('/.env') then dev_server.envFile = '../.env' end
+          if php.file_exists('/.env') then
+            -- Try to add compatibility with non-laravel project
+            dev_server.envFile = '../.env'
+          end
 
-          if php.is_laravel() then
-            local route_file = php.route_file()
-
-            if route_file ~= nil then
-              -- Assign route file when available
-              table.insert(dev_server.runtimeArgs, '../'..route_file)
-            end
+          if route_file ~= nil then
+            -- Assign route file when available
+            table.insert(dev_server.runtimeArgs, '../'..route_file)
           end
 
           table.insert(dap.configurations.php, dev_server)
@@ -185,7 +177,7 @@ return {
           table.insert(dap.configurations[lang], {
             type = 'pwa-chrome',
             request = 'launch',
-            name = 'Launch Chrome',
+            name = 'DAP: Launch Chrome',
             url = enter_launch_url,
             webRoot = '${workspaceFolder}',
             sourceMaps = true,
@@ -194,7 +186,7 @@ return {
           table.insert(dap.configurations[lang], {
             type = 'pwa-msedge',
             request = 'launch',
-            name = 'Launch MSEdge',
+            name = 'DAP: Launch MSEdge',
             url = enter_launch_url,
             webRoot = '${workspaceFolder}',
             sourceMaps = true,

--- a/lua/plugins/debug.lua
+++ b/lua/plugins/debug.lua
@@ -193,6 +193,25 @@ return {
           })
         end
       end
+
+      if mason_registry.is_installed('firefox-debug-adapter') then
+        dap.adapters.firefox = {
+          type = 'executable',
+          command = vim.fn.exepath('firefox-debug-adapter'),
+        }
+
+        for _, lang in ipairs(fe_langs) do
+          table.insert(dap.configurations[lang], {
+            type = 'firefox',
+            request = 'launch',
+            name = 'DAP: Launch Firefox',
+            url = enter_launch_url,
+            webRoot = '${workspaceFolder}',
+            sourceMaps = true,
+            firefoxExecutable = vim.fn.exepath('firefox')
+          })
+        end
+      end
     end,
   },
 

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -37,6 +37,11 @@ return {
           DapBreakpointRejected = { fg = colors.error },
           DapLogPoint = { fg = colors.selection_bg },
           DapStopped = { fg = colors.tag },
+          DapUIFloatBorder = { link = 'FloatBorder' },
+          DapUIFloatNormal = { link = 'NormalFloat' },
+
+          NvimDapVirtualText = { link = 'Comment' },
+          NvimDapVirtualTextChanged = { fg = colors.accent },
         },
       }
     end,

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -24,6 +24,9 @@ return {
           PmenuSel = { bg = colors.selection_bg },
           Visual = { bg = colors.selection_bg },
           NonText = { fg = colors.guide_active },
+
+          WinBar = { bg = 'none' },
+          WinBarNC = { bg = 'none' },
           WinSeparator = { fg = colors.comment, bg = 'none' },
 
           IblIndent = { fg = colors.guide_normal },

--- a/lua/plugins/treesitter.lua
+++ b/lua/plugins/treesitter.lua
@@ -34,6 +34,7 @@ return {
       { 'nvim-treesitter/nvim-treesitter-textobjects' },
       { 'JoosepAlviste/nvim-ts-context-commentstring' },
       { 'nvim-treesitter/nvim-treesitter-context', enabled = true },
+      { 'LiadOz/nvim-dap-repl-highlights', config = true },
     },
     opts = {
       indent = { enable = true },
@@ -43,6 +44,7 @@ return {
         'bash',
         'blade',
         'comment',
+        'dap_repl',
         'gitignore',
         'html',
         'json',


### PR DESCRIPTION
Sometimes having to starts debugger and dev server on separated process is quite cumbersome so I decided to do some experiment on how to start the dev server and debugger at once.

https://github.com/user-attachments/assets/2c8681ad-aed6-4899-bd0a-43371489738c

### Notes

Although the debug adapter is exactly the same as the one used in VS Code and the configuration is quite similar, but the way to configure it is not the same.

In VS Code we have access to their configuration variable like `${port}`, `${fileDirname}`. `${workspaceRoot}`, etc. But here in NeoVim DAP none of them seems to be working.

https://github.com/feryardiant/config-nvim/blob/4a568e1d41784a0f2719be7db8d873a186e4ac43/lua/plugins/debug.lua#L101-L102

Also in VS Code when we have `serverReadyAction.action` available, it will open the app url in our default browser, but here' we have to open the url manually.

https://github.com/feryardiant/config-nvim/blob/4a568e1d41784a0f2719be7db8d873a186e4ac43/lua/plugins/debug.lua#L104-L108

Last but not least, in VS Code when a request hit the breakpoint then the VS Code app will be focused, but here we have to switch back and forth manually.
