### PR TITLE
feat(telescope): add ability to render image using `image.nvim`

### DIFF
--- a/lua/plugins/telescope.lua
+++ b/lua/plugins/telescope.lua
@@ -32,6 +32,24 @@ return {
         layout_config = {
           vertical = { width = 0.5 },
         },
+        preview = {
+          mime_hook = function(filepath, buffer, hook_opts)
+            if require('util').is_image(filepath) then
+              local viewer = require('image')
+
+              local image = viewer.from_file(filepath, {
+                window = hook_opts.winid,
+                buffer = buffer,
+              })
+
+              ---@diagnostic disable-next-line: need-check-nil
+              image:render()
+            else
+              local previewer_util = require('telescope.previewers.utils')
+              previewer_util.set_preview_message(buffer, hook_opts.winid, 'Binary cannot be previewed')
+            end
+          end,
+        },
         mappings = {
           i = {
             ['<Esc>'] = actions.close,

--- a/lua/util.lua
+++ b/lua/util.lua
@@ -30,4 +30,14 @@ function util.create_keymap(default_opts)
   end
 end
 
+---@param file string
+---@return boolean
+function util.is_image(file)
+  local extensions = { 'jpg', 'jpeg', 'png' }
+  local splits = vim.split(file:lower(), '.', { plain = true })
+  local extension = splits[#splits]
+
+  return vim.tbl_contains(extensions, extension)
+end
+
 return util


### PR DESCRIPTION
Based on [their wiki](https://github.com/nvim-telescope/telescope.nvim/wiki/Configuration-Recipes#use-terminal-image-viewer-to-preview-images) I should be able to preview image files, but on their example is using [`catimg`](https://github.com/posva/catimg).

Can I use [`image.nvim`](https://github.com/3rd/image.nvim) instead?

https://github.com/user-attachments/assets/165df2d8-d6d5-4568-8b73-2ffd02d34f84

Sure enough, but barely usable as its in `neo-tree`. See #7 