### PR TITLE
fix(lsp): disable `denols` on non-`deno` project

### DIFF
--- a/lua/custom/php.lua
+++ b/lua/custom/php.lua
@@ -2,8 +2,6 @@
 local PHP = {}
 local uv = vim.uv or vim.loop
 
-function PHP.is_laravel() return PHP.file_exists('/artisan') end
-
 ---Check wheter file exists
 ---@param file_path string
 ---@return boolean

--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -69,6 +69,7 @@ return {
       opts.ensure_installed = vim.list_extend(ensure_installed, {
         'bashls',
         'dockerls',
+        'denols',
         'eslint',
         'nginx_language_server',
         'sqls',
@@ -106,6 +107,20 @@ return {
           lspconfig[server].setup(config)
         end,
       }
+
+      opts.handlers.denols = function(server)
+        servers[server] = {
+          settings = {
+            deno = vim.tbl_deep_extend('force', settings.deno, { enable = false })
+          }
+        }
+
+        if vim.uv.fs_stat(vim.fn.getcwd()..'/deno.json') ~= 0 then
+          servers[server].settings.deno.enable = true
+        end
+
+        opts.handlers[1](server)
+      end
 
       ---@param server string
       opts.handlers.ts_ls = function(server)

--- a/lua/plugins/lsp.lua
+++ b/lua/plugins/lsp.lua
@@ -108,16 +108,28 @@ return {
         end,
       }
 
+      opts.handlers.eslint = function(server)
+        servers[server] = {
+          settings = {
+            eslint = vim.tbl_deep_extend('force', settings.eslint, {
+              -- Disable eslint on a deno project
+              enable = not require('util').is_deno(),
+            }),
+          },
+        }
+
+        opts.handlers[1](server)
+      end
+
       opts.handlers.denols = function(server)
         servers[server] = {
           settings = {
-            deno = vim.tbl_deep_extend('force', settings.deno, { enable = false })
-          }
+            deno = vim.tbl_deep_extend('force', settings.deno, {
+              -- Disable denols on non-deno project
+              enable = require('util').is_deno(),
+            }),
+          },
         }
-
-        if vim.uv.fs_stat(vim.fn.getcwd()..'/deno.json') ~= 0 then
-          servers[server].settings.deno.enable = true
-        end
 
         opts.handlers[1](server)
       end

--- a/lua/settings.lua
+++ b/lua/settings.lua
@@ -42,6 +42,8 @@ return {
     },
   },
 
+  deno = {},
+
   js = {
     inlayHints = {
       functionLikeReturnTypes = { enabled = true },

--- a/lua/settings.lua
+++ b/lua/settings.lua
@@ -42,6 +42,8 @@ return {
     },
   },
 
+  eslint = {},
+
   deno = {},
 
   js = {

--- a/lua/util.lua
+++ b/lua/util.lua
@@ -1,4 +1,26 @@
 local util = {}
+local uv = vim.uv or vim.loop
+
+---Check whether file exists
+---@param ... string
+---@return boolean
+function util.file_exists(...)
+  for _, filepath in ipairs({ ... }) do
+    filepath = table.concat({ vim.fn.getcwd(), filepath }, '/')
+
+    if uv.fs_stat(filepath) ~= nil then return true end
+  end
+
+  return false
+end
+
+---Is it a Laravel project
+---@return boolean
+function util.is_laravel() return util.file_exists('artisan') end
+
+---Is it a Deno project
+---@return boolean
+function util.is_deno() return util.file_exists('deno.json', 'deno.jsonc', 'deno.lock') end
 
 ---@param default_opts? number|vim.keymap.set.Opts
 function util.create_keymap(default_opts)


### PR DESCRIPTION
Came across the exact same issue as described [here](https://stackoverflow.com/q/79349248/881743) and decided to workaround to overcome this issue and realized that (I assumed) it's not `denols` overlaping with `ts_ls`, but instead it `denols` overalping with `eslint`. I could be wrong about this anyway.

Regardless here my workaround
- Add utility to determine is it a deno project or not, indicated by these files

  https://github.com/feryardiant/config-nvim/blob/548441ce5d122c707d4333c4d9523e739abe5b35/lua/util.lua#L21-L23

- Disable `denols` on non-deno project, 

  https://github.com/feryardiant/config-nvim/blob/548441ce5d122c707d4333c4d9523e739abe5b35/lua/plugins/lsp.lua#L125-L131

- Disable `eslint` on a deno project, and use deno's [built-in linter](https://docs.deno.com/runtime/fundamentals/linting_and_formatting/) instead.

  https://github.com/feryardiant/config-nvim/blob/548441ce5d122c707d4333c4d9523e739abe5b35/lua/plugins/lsp.lua#L112-L118