### PR TITLE
fix(snacks): disable `statuscolumn` on all `dapui` windows

### DIFF
--- a/lua/plugins/snacks.lua
+++ b/lua/plugins/snacks.lua
@@ -84,5 +84,17 @@ return {
       terminal = {},
       win = { backdrop = false },
     },
+    init = function()
+      vim.api.nvim_create_autocmd('BufWinEnter', {
+        callback = function()
+          local ft = vim.bo.ft
+
+          if ft == 'dap-repl' or ft:match('^dapui_') then
+            -- Disable status column on DAP windows
+            vim.wo.statuscolumn = ''
+          end
+        end,
+      })
+    end,
   },
 }


### PR DESCRIPTION
Just recently got annoyed by the gap caused by `snacks.statuscolumn` on `dapui` windows.

![image](https://github.com/user-attachments/assets/359f897e-2898-4a83-a46f-062af044c644)

Doing some experiments but got no luck, then I gave up and decided to ask in the forum. Fortunately someone kind enough to [help me out](https://github.com/folke/snacks.nvim/discussions/1484#discussioncomment-12368233).