### PR TITLE
feat(debug): messing around with debugging configs

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
+  "runtime.version": "LuaJIT",
+  "diagnostics.globals": ["vim", "Snacks"],
+  "workspace.checkThirdParty": false,
+  "workspace.library": ["./lua", "$VIMRUNTIME/lua"]
+}

--- a/lua/custom/php.lua
+++ b/lua/custom/php.lua
@@ -28,4 +28,28 @@ function PHP.route_file()
   return nil
 end
 
+local _class_name_caches = {}
+
+---Retrieve basename of a class
+---@param class_name string
+function PHP.class_basename(class_name)
+  if _class_name_caches[class_name] ~= nil then
+    return _class_name_caches[class_name]
+  end
+
+  local parts = {}
+  local pos = 0
+
+  while true do
+    ---@diagnostic disable-next-line: cast-local-type
+    pos = string.find(class_name, '\\', pos+1)
+    if pos == nil then break end
+    table.insert(parts, pos)
+  end
+
+  _class_name_caches[class_name] = class_name:sub(parts[#parts] + 1)
+
+  return _class_name_caches[class_name]
+end
+
 return PHP

--- a/lua/keymaps.lua
+++ b/lua/keymaps.lua
@@ -1,6 +1,14 @@
 local map = require('util').create_keymap()
 local noremap = require('util').create_keymap({ noremap = true })
 
+vim.api.nvim_create_autocmd('FileType', {
+  pattern = { 'qf', 'help', 'man', 'nofile', 'lspinfo' },
+  callback = function (event)
+    vim.bo[event.buf].buflisted = false
+    vim.api.nvim_buf_set_keymap(event.buf, 'n', 'q', '<Cmd>close<CR>', { silent = true })
+  end
+})
+
 -- Clear search with <ESC>
 map('n', '<Esc>', '<Cmd>nohlsearch<CR>', { desc = 'Clear search highlight' })
 

--- a/lua/plugins/debug.lua
+++ b/lua/plugins/debug.lua
@@ -80,11 +80,18 @@ return {
     },
     init = function()
       -- Credit: https://github.com/mfussenegger/nvim-dap/discussions/355
-      vim.fn.sign_define('DapBreakpoint', { text = '󰃤', texthl = 'DapBreakpoint' })
-      vim.fn.sign_define('DapBreakpointCondition', { text = '󰃤', texthl = 'DapBreakpointCondition' })
-      vim.fn.sign_define('DapBreakpointRejected', { text = '󰃤', texthl = 'DapBreakpointRejected' })
-      vim.fn.sign_define('DapLogPoint', { text = '', texthl = 'DapLogPoint' })
-      vim.fn.sign_define('DapStopped', { text = '', texthl = 'DapStopped' })
+      local sings = {
+        Breakpoint = '',
+        BreakpointCondition = '',
+        BreakpointRejected = '',
+        LogPoint = '',
+        Stopped = '',
+      }
+
+      for label, icon in pairs(sings) do
+        label = 'Dap' .. label
+        vim.fn.sign_define(label, { text = icon, texthl = label })
+      end
     end,
     config = function()
       local dap, util = require('dap'), require('util')

--- a/lua/plugins/debug.lua
+++ b/lua/plugins/debug.lua
@@ -6,9 +6,10 @@ return {
       { 'theHamsta/nvim-dap-virtual-text' },
       { 'LiadOz/nvim-dap-repl-highlights', config = true },
     },
+    cmd = { 'DapContinue', 'DapToggleBreakpoint' },
     keys = {
-      { '<F5>', function() require('dap').continue() end, desc = 'Debug: Start/Continue' },
-      { '<leader>db', function() require('dap').toggle_breakpoint() end, desc = 'Debug: Toggle Breakpoint' },
+      { '<F5>', '<cmd>DapContinue<CR>', desc = 'Debug: Start/Continue' },
+      { '<leader>db', '<cmd>DapToggleBreakpoint<CR>', desc = 'Debug: Toggle Breakpoint' },
       {
         '<leader>d',
         function()

--- a/lua/plugins/debug.lua
+++ b/lua/plugins/debug.lua
@@ -47,6 +47,14 @@ return {
         label = 'Dap' .. label
         vim.fn.sign_define(label, { text = icon, texthl = label })
       end
+
+      vim.api.nvim_create_autocmd('FileType', {
+        pattern = 'dap-repl',
+        callback = function ()
+          ---@see dap-completion
+          require('dap.ext.autocompl').attach()
+        end
+      })
     end,
     ---@diagnostic disable: inject-field
     config = function()

--- a/lua/plugins/debug.lua
+++ b/lua/plugins/debug.lua
@@ -134,16 +134,11 @@ return {
             name = 'DAP: Launch Built-in Server and Debug',
             cwd = vim.fn.getcwd() .. '/public',
             port = xdebug_port,
-            runtimeArgs = {
-              '-dxdebug.client_host=127.0.0.1',
-              '-dxdebug.client_port=' .. xdebug_port,
-              '-dxdebug.mode=debug',
-              '-dxdebug.start_with_request=yes',
-              '-S',
-              'localhost:8000',
-              '-t',
-              '.',
+            env = {
+              XDEBUG_CONFIG = 'client_host=127.0.0.1 client_port=${port}',
+              XDEBUG_MODE = 'debug',
             },
+            runtimeArgs = { '-dxdebug.start_with_request=yes', '-S', 'localhost:8000', '-t', '.' },
           }
 
           if util.file_exists('.env') then

--- a/lua/plugins/debug.lua
+++ b/lua/plugins/debug.lua
@@ -61,7 +61,7 @@ return {
         map('n', '<F2>', dap.step_over, { desc = 'Debug: Step over' })
         map('n', '<F3>', dap.step_out, { desc = 'Debug: Step out' })
         map('n', '<F4>', dap.step_back, { desc = 'Debug: Step back' })
-        map('n', '<leader>de', function() dapui.eval(nil, { enter = true }) end, { desc = 'Debug: Evaluate value' })
+        map('n', '<leader>dd', function() dapui.eval(nil, { enter = true }) end, { desc = 'Debug: Evaluate value' })
         map('n', '<leader>dc', dap.clear_breakpoints, { desc = 'Debug: Clear breakpoints' })
 
         dapui.open()
@@ -84,6 +84,28 @@ return {
     keys = {
       { '<F5>', function() require('dap').continue() end, desc = 'Debug: Start/Continue' },
       { '<leader>db', function() require('dap').toggle_breakpoint() end, desc = 'Debug: Toggle Breakpoint' },
+      {
+        '<leader>d',
+        function()
+          local items = {
+            'Add conditional breakpoint',
+            'Add hit condition',
+            'Add log point',
+          }
+
+          Snacks.picker.select(items, { prompt = 'Set Breakpoint' }, function(label, idx)
+            local dap, param = require('dap'), vim.fn.input(label .. ': ')
+            local cases = {
+              [1] = function() dap.set_breakpoint(param, nil, nil) end,
+              [2] = function() dap.set_breakpoint(nil, param, nil) end,
+              [3] = function() dap.set_breakpoint(nil, nil, param) end,
+            }
+
+            cases[idx]()
+          end)
+        end,
+        desc = 'Debug: Set Breakpoint',
+      },
     },
     init = function()
       -- Credit: https://github.com/mfussenegger/nvim-dap/discussions/355

--- a/lua/plugins/debug.lua
+++ b/lua/plugins/debug.lua
@@ -56,14 +56,21 @@ return {
       local dap, dapui = require('dap'), require('dapui')
       local map = require('util').create_keymap()
 
-      dap.listeners.before.attach.dapui_config = dapui.open
-      dap.listeners.before.launch.dapui_config = dapui.open
+      dap.listeners.after.event_initialized.dapui_config = function()
+        map('n', '<F1>', dap.step_into, { desc = 'Debug: Step into' })
+        map('n', '<F2>', dap.step_over, { desc = 'Debug: Step over' })
+        map('n', '<F3>', dap.step_out, { desc = 'Debug: Step out' })
+        map('n', '<F4>', dap.step_back, { desc = 'Debug: Step back' })
+        map('n', '<leader>de', function() dapui.eval(nil, { enter = true }) end, { desc = 'Debug: Evaluate value' })
+        map('n', '<leader>dc', dap.clear_breakpoints, { desc = 'Debug: Clear breakpoints' })
+
+        dapui.open()
+      end
+
       dap.listeners.before.event_terminated.dapui_config = dapui.close
       dap.listeners.before.event_exited.dapui_config = dapui.close
 
       dapui.setup(opts)
-
-      map('n', '<leader>?', function() dapui.eval(nil, { enter = true }) end, { desc = 'Debug: Evaluate value' })
     end,
   },
 
@@ -96,12 +103,6 @@ return {
     config = function()
       local dap, util = require('dap'), require('util')
       local mason_registry = require('mason-registry')
-      local map = util.create_keymap()
-
-      map('n', '<F1>', dap.step_into, { desc = 'Debug: Step into' })
-      map('n', '<F2>', dap.step_over, { desc = 'Debug: Step over' })
-      map('n', '<F3>', dap.step_out, { desc = 'Debug: Step out' })
-      map('n', '<F4>', dap.step_back, { desc = 'Debug: Step back' })
 
       -- PHP debug config
 

--- a/lua/plugins/debug.lua
+++ b/lua/plugins/debug.lua
@@ -56,6 +56,7 @@ return {
       -- see https://github.com/feryardiant/config-nvim/pull/19
       local session_id = nil
 
+      ---@param session dap.Session
       dap.listeners.before.event_initialized.dapui_config = function(session)
         local map = util.create_keymap()
 

--- a/lua/plugins/debug.lua
+++ b/lua/plugins/debug.lua
@@ -346,6 +346,8 @@ return {
 
         if name:match('secret') or name:match('key') or name:match('api') then
           output = '****'
+        elseif output:find('\\') ~= nil then
+          output = '…\\' .. require('custom.php').class_basename(output)
         elseif #value > 10 then
           output = output:sub(1, 10) .. '…'
         end

--- a/lua/plugins/debug.lua
+++ b/lua/plugins/debug.lua
@@ -52,26 +52,6 @@ return {
         },
       },
     },
-    config = function(_, opts)
-      local dap, dapui = require('dap'), require('dapui')
-      local map = require('util').create_keymap()
-
-      dap.listeners.after.event_initialized.dapui_config = function()
-        map('n', '<F1>', dap.step_into, { desc = 'Debug: Step into' })
-        map('n', '<F2>', dap.step_over, { desc = 'Debug: Step over' })
-        map('n', '<F3>', dap.step_out, { desc = 'Debug: Step out' })
-        map('n', '<F4>', dap.step_back, { desc = 'Debug: Step back' })
-        map('n', '<leader>dd', function() dapui.eval(nil, { enter = true }) end, { desc = 'Debug: Evaluate value' })
-        map('n', '<leader>dc', dap.clear_breakpoints, { desc = 'Debug: Clear breakpoints' })
-
-        dapui.open()
-      end
-
-      dap.listeners.before.event_terminated.dapui_config = dapui.close
-      dap.listeners.before.event_exited.dapui_config = dapui.close
-
-      dapui.setup(opts)
-    end,
   },
 
   {
@@ -125,6 +105,28 @@ return {
     config = function()
       local dap, util = require('dap'), require('util')
       local mason_registry = require('mason-registry')
+
+      dap.listeners.before.event_initialized.dapui_config = function()
+        local dapui, map = require('dapui'), util.create_keymap()
+
+        map('n', '<F1>', dap.step_into, { desc = 'Debug: Step into' })
+        map('n', '<F2>', dap.step_over, { desc = 'Debug: Step over' })
+        map('n', '<F3>', dap.step_out, { desc = 'Debug: Step out' })
+        map('n', '<F4>', dap.step_back, { desc = 'Debug: Step back' })
+        map('n', '<leader>dd', function() dapui.eval(nil, { enter = true }) end, { desc = 'Debug: Evaluate value' })
+        map('n', '<leader>dc', dap.clear_breakpoints, { desc = 'Debug: Clear breakpoints' })
+
+        dapui.open()
+      end
+
+      dap.listeners.before.event_terminated.dapui_config = function()
+        local dapui, sessions = require('dapui'), dap.sessions()
+
+        if #sessions == 1 then
+          -- Close dapui when there's only 1 session available
+          dapui.close()
+        end
+      end
 
       -- PHP debug config
 

--- a/lua/plugins/debug.lua
+++ b/lua/plugins/debug.lua
@@ -287,23 +287,23 @@ return {
     ---@module 'nvim-dap-virtual-text'
     ---@type nvim_dap_virtual_text_options
     opts = {
-      display_callback = function(var)
+      display_callback = function(var, _, _, _, opts)
         local name = var.name:lower()
         local value = var.value:lower()
-
-        if name:match('secret') or name:match('key') or name:match('api') then
-          -- Hide sensitive values
-          return ' *****'
-        end
-
         local output = var.value:gsub('%s+', ' ')
 
-        if #value > 10 then
-          -- Shorten long value
+        if name:match('secret') or name:match('key') or name:match('api') then
+          output = '****'
+        elseif #value > 10 then
           output = output:sub(1, 10) .. '…'
         end
 
-        return ' ' .. output
+        if opts.virt_text_pos == 'inline' then
+          -- Print the output
+          return '→ ' .. output
+        end
+
+        return string.format('%s→ %s', var.name, output)
       end,
     },
   },

--- a/lua/plugins/debug.lua
+++ b/lua/plugins/debug.lua
@@ -1,60 +1,5 @@
 return {
   {
-    'jay-babu/mason-nvim-dap.nvim',
-    lazy = true,
-    dependencies = {
-      { 'williamboman/mason.nvim' },
-    },
-    ---@module 'mason-nvim-dap'
-    ---@type MasonNvimDapSettings
-    opts = {
-      ensure_installed = {
-        'firefox-debug-adapter',
-        'js-debug-adapter',
-        'node-debug2-adapter',
-        'php-debug-adapter',
-      },
-    },
-  },
-
-  {
-    'rcarriga/nvim-dap-ui',
-    dependencies = {
-      { 'mfussenegger/nvim-dap' },
-      { 'nvim-neotest/nvim-nio' },
-    },
-    keys = {
-      { '<F7>', function() require('dapui').toggle() end, desc = 'Debug: Toggle UI' },
-    },
-    ---@module 'dapui'
-    ---@type dapui.Config
-    opts = {
-      controls = { element = 'watches' },
-      floating = { border = 'rounded' },
-      layouts = {
-        {
-          size = 32,
-          position = 'right',
-          elements = {
-            { size = 0.3, id = 'scopes' },
-            { size = 0.3, id = 'stacks' },
-            { size = 0.2, id = 'breakpoints' },
-            { size = 0.2, id = 'watches' },
-          },
-        },
-        {
-          size = 10,
-          position = 'bottom',
-          elements = {
-            { size = 0.6, id = 'repl' },
-            { size = 0.4, id = 'console' },
-          },
-        },
-      },
-    },
-  },
-
-  {
     'mfussenegger/nvim-dap',
     dependencies = {
       { 'jay-babu/mason-nvim-dap.nvim' },
@@ -321,6 +266,61 @@ return {
         end
       end
     end,
+  },
+
+  {
+    'rcarriga/nvim-dap-ui',
+    dependencies = {
+      { 'mfussenegger/nvim-dap' },
+      { 'nvim-neotest/nvim-nio' },
+    },
+    keys = {
+      { '<F7>', function() require('dapui').toggle() end, desc = 'Debug: Toggle UI' },
+    },
+    ---@module 'dapui'
+    ---@type dapui.Config
+    opts = {
+      controls = { element = 'watches' },
+      floating = { border = 'rounded' },
+      layouts = {
+        {
+          size = 32,
+          position = 'right',
+          elements = {
+            { size = 0.3, id = 'scopes' },
+            { size = 0.3, id = 'stacks' },
+            { size = 0.2, id = 'breakpoints' },
+            { size = 0.2, id = 'watches' },
+          },
+        },
+        {
+          size = 10,
+          position = 'bottom',
+          elements = {
+            { size = 0.6, id = 'repl' },
+            { size = 0.4, id = 'console' },
+          },
+        },
+      },
+    },
+  },
+
+  {
+    'jay-babu/mason-nvim-dap.nvim',
+    lazy = true,
+    dependencies = {
+      { 'williamboman/mason.nvim' },
+    },
+    ---@module 'mason-nvim-dap'
+    ---@type MasonNvimDapSettings
+    opts = {
+      ensure_installed = {
+        'firefox-debug-adapter',
+        'js-debug-adapter',
+        'node-debug2-adapter',
+        'php-debug-adapter',
+      },
+    },
   },
 
   {

--- a/lua/plugins/editor.lua
+++ b/lua/plugins/editor.lua
@@ -28,16 +28,16 @@ return {
         lsp_doc_border = true, -- add a border to hover docs and signature help
       }
 
-      -- opts.routes = {
-      --   -- Credit: https://github.com/neovim/nvim-lspconfig/issues/1931#issuecomment-2138428768
-      --   {
-      --     filter = {
-      --       event = 'notify',
-      --       find = 'No information available',
-      --     },
-      --     opts = { skip = true },
-      --   },
-      -- }
+      opts.routes = {
+        -- Credit: https://github.com/neovim/nvim-lspconfig/issues/1931#issuecomment-2138428768
+        {
+          filter = {
+            event = 'notify',
+            find = 'No information available',
+          },
+          opts = { skip = true },
+        },
+      }
     end,
   },
 

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -62,8 +62,10 @@ return {
         SnacksBackdrop = { link = 'WinBar' },
         SnacksIndent = { fg = colors.guide_normal },
         SnacksIndentScope = { fg = colors.accent },
+        SnacksNormal = { link = 'Normal' },
         SnacksPicker = { link = 'WinBar' },
         SnacksTerminal = { link = 'WinBar' },
+        SnacksWinBar = { link = 'WinBar' },
 
         TreesitterContext = { link = 'NormalFloat' },
 

--- a/lua/plugins/init.lua
+++ b/lua/plugins/init.lua
@@ -43,7 +43,7 @@ return {
         DapBreakpoint = { fg = colors.accent },
         DapBreakpointCondition = { fg = colors.warning },
         DapBreakpointRejected = { fg = colors.error },
-        DapLogPoint = { fg = colors.selection_bg },
+        DapLogPoint = { fg = colors.accent },
         DapStopped = { fg = colors.tag },
         DapUIFloatBorder = { link = 'FloatBorder' },
         DapUIFloatNormal = { link = 'NormalFloat' },

--- a/lua/plugins/snacks.lua
+++ b/lua/plugins/snacks.lua
@@ -22,7 +22,7 @@ return {
       { '<leader>fg', function() Snacks.picker.git_files() end, desc = '[F]ind Current [G]it Repo' },
       { '<leader>r', function() Snacks.rename.rename_file() end, desc = '[R]ename File' },
       -- Diagnostics
-      { '<leader>d', function() Snacks.picker.diagnostics() end, desc = 'Open [D]iagnostics' },
+      { '<leader>do', function() Snacks.picker.diagnostics() end, desc = 'Open [D]iagnostics' },
       { '<leader>da', function() Snacks.picker.diagnostics_buffer() end, desc = 'Open [D]iagnostics Buffer' },
       -- Searches
       { '<leader>sw', function() Snacks.picker.grep_word() end, desc = '[S]earch by [W]ord', mode = { 'n', 'x' } },


### PR DESCRIPTION
Initially I was wondering why `dapui` won't open when starting `dap` session. Then, I figured that my keymap was a mess 😅

Figured out that f878aff was the main causes `dapui` won't starts, the reason being that `dap.listeners` should be initialized along side the `dap` itself and in that commit I put the listeners on the `dapui` initialization which is not initialized at all. So I move back all the listeners to their original place.

While I'm working around the way to use LogPoint and Conditional Breakpoints I figured out that I missed some functionalities that available for me to use while debugging, e.g. Clear Breakpoints, Set Exception Breakpoints, etc.

On their documentation (`:help dap-mappings`) they've [mentioned](https://github.com/mfussenegger/nvim-dap/blob/379cf26/doc/dap.txt#L503-L504) `<leader>B` and `<leader>lp` that invoke `dap.set_breakpoint()` and got me thinking "is that `lp` means LogPoint?". Then I read the [`:h dap.set_breakpoint()`](https://github.com/mfussenegger/nvim-dap/blob/379cf26/doc/dap.txt#L789-L808) and realized that this is what I'm looking for, right?

Basically the documentation state that :
- Pass the first parameter with a _condition_ I want it to break or `nil` if otherwise
- Pass the second parameter with a _condition when_ I want it to break or `nil` if otherwise
- Pass the third parameter with a _message_ what I want to log in repl console

Meanwhile I'm also wondering which keys should I use to map all these functionalities? I'd love to see every debugging aspects should be under `<leader>d` keymap, but that one already mapped to `diagnostics`. Hmmm, why don't just remap it and map it to `set_breakpoint()`?

### So

- `<leader>do` : Open diagnostics, replacing `<leader>d`
- `<leader>d` : Show select menu to set_breakpoint
- `<leader>db` : Toggle breakpoints
- `<leader>dc` : Clear all breakpoints
- `<leader>dd` : Evaluate value, replacing `<leader>?`
- `<leader>dx` : Set exception breakpoints, still need to learn it further tho

Also I've manage that all debug keymaps only available while debug session is running. Because I think it just make more sense to have those keymaps only while debugging and not the otherwise.

### What else?

There's a thing that quite bothering me that when I `launch` debug session, the cli output is printed in `dap-repl` console [instead of `dapui_console`](https://github.com/rcarriga/nvim-dap-ui/issues/306), the only documentation I found is from [`vscode`](https://code.visualstudio.com/docs/editor/debugging-configuration#_launchjson-attributes) that suggesting that the way to move the output is by changing the value of `console` in the `configutions`. But the only option we have is just `integratedTerminal, `externalTerminal` and `internalTerminal`. Which `internalTerminal` is the defaults one it is actually the `dap-repl` console, instead of `dapui_console`.

At this point I'm quite happy with the results, thought I'm still wondering how to make these keymap to only available when the breakpoint hit

https://github.com/feryardiant/config-nvim/blob/933aacb14e6b8ea715d5c2bcad084c4bcedaf955/lua/plugins/debug.lua#L112-L115
