### PR TITLE
feat(php): ability to automatically registers `intelephense.stubs` based on installed extensions

### DIFF
--- a/lua/custom/php.lua
+++ b/lua/custom/php.lua
@@ -9,8 +9,29 @@ function PHP.is_laravel() return util.file_exists('artisan') end
 ---Retrieve xdebug port
 ---@return number
 function PHP.xdebug_port()
+  local output = PHP.exec('ini_get("xdebug.client_port")')
+
   -- Default xdebug port
-  return 9003
+  return tonumber(output) or 9003
+end
+
+---Run php script as you commonly use `php -r "echo ..."`
+---@param arg string
+---@return string
+function PHP.exec(arg)
+  local co = coroutine.create(function()
+    local args = { 'php', '-r', string.format("'echo %s;'", arg) }
+    local result = assert(io.popen(table.concat(args, ' '), 'r'))
+    local output = result:read('*a')
+
+    coroutine.yield(output)
+
+    result:close()
+  end)
+
+  local _, value = coroutine.resume(co)
+
+  return value
 end
 
 ---Retrieve route file

--- a/lua/custom/php.lua
+++ b/lua/custom/php.lua
@@ -6,6 +6,39 @@ local util = require('util')
 ---@return boolean
 function PHP.is_laravel() return util.file_exists('artisan') end
 
+---Retrieve global `COMPOSER_HOME` directory
+---@return string?
+function PHP.composer_home()
+  local home = os.getenv('COMPOSER_HOME')
+
+  return vim.fn.isdirectory(home) and home or nil
+end
+
+---Retrieve global include paths
+---@return table
+function PHP.include_paths()
+  local paths = {}
+  local composer_home = PHP.composer_home()
+
+  assert(composer_home, '$COMPOSER_HOME directory doesn exists')
+
+  local should_available = {}
+
+  if PHP.has_extension('openswoole') then
+    table.insert(should_available, 'openswoole/ide-helper')
+  end
+
+  for _, pkg_path in ipairs(should_available) do
+    pkg_path = string.format('%s/vendor/%s', composer_home, pkg_path)
+
+    if vim.fn.isdirectory(pkg_path) then
+      table.insert(paths, pkg_path)
+    end
+  end
+
+  return paths
+end
+
 ---Retrieve xdebug port
 ---@return number
 function PHP.xdebug_port()

--- a/lua/custom/php.lua
+++ b/lua/custom/php.lua
@@ -75,6 +75,18 @@ end
 
 local _installed_extensions = {}
 
+---Check wheter `ext` is installed
+---@param ext string
+---@return boolean
+function PHP.has_extension(ext)
+  for _, installed in ipairs(PHP.installed_extensions()) do
+    if ext == installed then
+      return true
+    end
+  end
+  return false
+end
+
 ---@return string[]
 function PHP.installed_extensions()
   if #_installed_extensions > 0 then

--- a/lua/settings.lua
+++ b/lua/settings.lua
@@ -1,3 +1,5 @@
+local php = require('custom.php')
+
 return {
   css = {
     lint = {
@@ -15,7 +17,7 @@ return {
 
   intelephense = {
     environment = {
-      includePaths = {},
+      includePaths = php.include_paths(),
     },
     files = {
       maxSize = 5000000,
@@ -40,7 +42,7 @@ return {
         '**/vendor/**',
       },
     },
-    stubs = require('custom.php').collect_stubs()
+    stubs = php.collect_stubs()
   },
 
   eslint = {},

--- a/lua/settings.lua
+++ b/lua/settings.lua
@@ -40,6 +40,7 @@ return {
         '**/vendor/**',
       },
     },
+    stubs = require('custom.php').collect_stubs()
   },
 
   eslint = {},


### PR DESCRIPTION
One downside of `intelephense` is they doesn't have the ability to automatically provides the stubs based on installed extension. Even in `vscode` we have to manually add the stubs we need ourselves.

Moreover, we can't just add the stub we need, instead we have to list all of their default stubs and add ours. At least they've [document](https://github.com/bmewburn/intelephense-docs/blob/master/installation.md#configuration-options) it somewhere in their repo.

Though the stubs is basically using the extension name, [I couldn't see any plan or interest](https://github.com/bmewburn/vscode-intelephense/issues/2224#issuecomment-1368398280) for them to add stubs for `openswoole`. Fortunately the `openswoole` themselves provide an [`ide-helper`](https://github.com/openswoole/ide-helper) to solve the issue.

So, the main goal of this PR is.
- [x] Check all installed extension and add them to the stubs
- [x] Check whether some composer packages are globally installed so we can add them to `intelephense.environment.includePaths`

That said, I've also add some methods to `custom.php` util to
- `php.composer_home()` to retrieve value of `$COMPOSER_HOME` and ensure the directory is exists, otherwise it returns `nil`
- `php.exec(arg)` execute simple PHP script, it's basically the same as `php -r 'echo ...;'` in the terminal.
- `php.installed_extensions()` to retrieve all installed extensions
- `php.has_extension(ext)` to check whether the extension is installed